### PR TITLE
Clarified the description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The magic part is that the program will find the other person over the local
 network or even the internet automatically, without needing to exchange IP
-addresses. Just a direct pipe to another peer.
+addresses, based on a topic string. Just a direct pipe to another peer.
 
 ## Usage
 


### PR DESCRIPTION
Without the mention of topic strings, the description felt like a joke/scam, since it implied it could find the other party without any unique identifier.